### PR TITLE
Resolved memory leak in dmtx_encode function

### DIFF
--- a/memory_test.py
+++ b/memory_test.py
@@ -1,0 +1,27 @@
+import random
+import pydmtx
+from time import sleep
+from cStringIO import StringIO
+
+
+def gen():
+    dm = pydmtx.DataMatrix(
+        module_size=2,
+        scheme=pydmtx.DataMatrix.DmtxSchemeC40,
+        shape=pydmtx.DataMatrix.DmtxSymbol44x44)
+    def empty(*args, **kwargs):
+        pass
+    # dm._start = dm._plot = empty
+    dm.encode("".join([str(random.randint(0, 100)) for _ in range(100)]))
+    image = StringIO()
+    dm.save(image, 'PNG')
+
+
+if __name__ == '__main__':
+    counter = 0
+    while True:
+        gen()
+        sleep(0.2)
+        counter += 1
+        if counter % 1000 == 0:
+            print counter

--- a/pydmtxmodule.c
+++ b/pydmtxmodule.c
@@ -97,6 +97,8 @@ dmtx_encode(PyObject *self, PyObject *arglist, PyObject *kwargs)
          &shape, &plotter, &start_cb, &finish_cb, &context))
       return NULL;
 
+   Py_DECREF(filtered_kwargs);
+
    Py_INCREF(context);
 
    /* Plotter is required, and must be callable */


### PR DESCRIPTION
Reference to filtered_kwargs object was not properly decreased.

Also introduced memory_test.py module for testing memory consumption.